### PR TITLE
better caching, init option, v0.6 update

### DIFF
--- a/torchserve_dashboard/__init__.py
+++ b/torchserve_dashboard/__init__.py
@@ -3,7 +3,7 @@ import logging as __logging
 import os
 from  datetime import date
 
-__version__ = 'v0.5.0'
+__version__ = 'v0.6.0'
 
 __author_name__ = 'Ceyda Cinarel'
 __author_email__ = '15624271+cceyda@users.noreply.github.com'

--- a/torchserve_dashboard/api.py
+++ b/torchserve_dashboard/api.py
@@ -95,6 +95,9 @@ class LocalTS:
         except (subprocess.CalledProcessError, OSError) as e:
             return e
 
+    def get_model_store(self) -> List[str]:
+        return os.listdir(self.model_store)
+
 
 class ManagementAPI:
     def __init__(self, address: str, error_callback: Callable = None) -> None:
@@ -118,12 +121,15 @@ class ManagementAPI:
     def get_model(self,
                   model_name: str,
                   version: Optional[str] = None,
-                  list_all: bool = False) -> List[Dict[str, Any]]:
+                  list_all: bool = False,
+                  custom_metadata: bool = False) -> List[Dict[str, Any]]:
         req_url = self.address + "/models/" + model_name
         if version:
             req_url += "/" + version
         elif list_all:
             req_url += "/all"
+        if custom_metadata:
+            req_url += "?customized=true"
 
         res = self.client.get(req_url)
         return res.json()

--- a/torchserve_dashboard/dash.py
+++ b/torchserve_dashboard/dash.py
@@ -5,7 +5,7 @@ import streamlit as st
 from httpx import Response
 
 from torchserve_dashboard.api import ManagementAPI, LocalTS
-from pathlib import Path
+from pathlib import Path 
 
 st.set_page_config(
     page_title="Torchserve Management Dashboard",
@@ -14,38 +14,22 @@ st.set_page_config(
     initial_sidebar_state="expanded",
 )
 
-parser = argparse.ArgumentParser(description="Torchserve Dashboard")
+def rerun():
+    st.experimental_rerun()
 
-parser.add_argument(
-    "--model_store", default=None, help="Directory where your models are stored (overrides config)"
-)
-parser.add_argument(
-    "--config_path",
-    default="./torchserve.properties",
-    help="Torchserve config path",
-)
-parser.add_argument(
-    "--log_location",
-    default="./logs/",
-    help="Passed as environment variable LOG_LOCATION to Torchserve",
-)
-parser.add_argument(
-    "--metrics_location",
-    default="./logs/metrics/",
-    help="Passed as environment variable METRICS_LOCATION to Torchserve",
-)
-parser.add_argument(
-    "--log_config",
-    default=None,
-    help="Overrides the default log4j.properties",
-)
-try:
-    args = parser.parse_args()
-except SystemExit as e:
-    os._exit(e.code)
+def error_callback(response:Response):
+    if response.status_code != 200:
+        st.write("There was an error!")
+        st.write(response)
 
-# Clean this up later
-def check_args(args):
+@st.cache(allow_output_mutation=True)
+def last_res():
+    return ["Nothing"]
+
+@st.experimental_singleton(suppress_st_warning=True)
+def check_args(_args):
+
+    args=_args
     M_API = "http://127.0.0.1:8081"
     model_store = args.model_store
     config_path = args.config_path
@@ -83,263 +67,296 @@ def check_args(args):
 
     return M_API, config, model_store, config_path, log_location, metrics_location, log_config
 
+@st.experimental_singleton(suppress_st_warning=True)
+def initialize(_args):
+    # Initialization should be done once! 
+    # As a design choice config_path,log_location,metrics_location are non-editable from the UI as a semi-security measure. Can only pass from command line.
+    api_address, config, model_store, config_path, log_location, metrics_location, log_config = check_args(_args)
+    api = ManagementAPI(api_address, error_callback)
+    ts = LocalTS(model_store, config_path, log_location, metrics_location, log_config)
+    torchserve_status = api.get_loaded_models()
+    if not torchserve_status and args.init:
+        st.write("Starting Torchserve")
+        last_res()[0] = ts.start_torchserve()
+        rerun()
+    return config, api, ts
 
-st.title("Torchserve Management Dashboard")
-default_key = "None"
-api_address, config, model_store, config_path, log_location, metrics_location, log_config = check_args(args)
+def dashboard(args):
+    st.title("Torchserve Management Dashboard")
+    default_key = "None"
+    config, api, ts = initialize(args)
+    ts_version,ts_error=ts.check_version() # doing it this way rather than ts.__version__ on purpose
+    if ts_error:
+        st.error(ts_error)
+        st.stop()
 
+    support_workflow=False #Temp workaround
+    if '0.4' in ts_version:
+        support_workflow=True
 
-def rerun():
-    st.experimental_rerun()
+    ##########Sidebar##########
+    st.sidebar.markdown("## Help")
+    with st.sidebar.expander(label="Show Paths:", expanded=False):
+        st.markdown(f"### Model Store Path: \n {ts.model_store}")
+        st.markdown(f"### Config Path: \n {ts.config_path}")
+        st.markdown(f"### Log Location: \n {ts.log_location}")
+        st.markdown(f"### Metrics Location: \n {ts.metrics_location}")
+    st.sidebar.write(ts_version)
+    start = st.sidebar.button("Start Torchserve")
+    if start:
+        last_res()[0] = ts.start_torchserve()
+        rerun()
 
+    stop = st.sidebar.button("Stop Torchserve")
+    if stop:
+        last_res()[0] = ts.stop_torchserve()
+        rerun()
 
-def error_callback(response:Response):
-    if response.status_code != 200:
-        st.write("There was an error!")
-        st.write(response)
+    torchserve_status = api.get_loaded_models()
+    if torchserve_status:
+        loaded_models_names = [m["modelName"] for m in torchserve_status["models"]]
+    else:
+        st.header("Torchserve is down...")
+    st.sidebar.subheader("Loaded models")
+    st.sidebar.write(torchserve_status)
 
+    stored_models = ts.get_model_store()
+    st.sidebar.subheader("Available models")
+    st.sidebar.write(stored_models)
+    ####################
 
-@st.cache(allow_output_mutation=True)
-def last_res():
-    return ["Nothing"]
+    st.markdown(f"**Last Message**: {last_res()[0]}")
 
+    with st.expander(label="Show torchserve config", expanded=False):
+        st.write(config)
+        st.markdown("[configuration docs](https://pytorch.org/serve/configuration.html)")
 
-def get_model_store():
-    return os.listdir(model_store)
+    if torchserve_status:
 
+        with st.expander(label="Register a model", expanded=False):
 
-api = ManagementAPI(api_address, error_callback)
-ts = LocalTS(model_store, config_path, log_location, metrics_location, log_config)
-ts_version,ts_error=ts.check_version() # doing it this way rather than ts.__version__ on purpose
-if ts_error:
-    st.error(ts_error)
-    st.stop()
-
-support_workflow=False #Temp workaround
-if '0.4' in ts_version:
-    support_workflow=True
-
-# As a design choice I'm leaving config_path,log_location,metrics_location non-editable from the UI as a semi-security measure (maybe?:/)
-##########Sidebar##########
-st.sidebar.markdown("## Help")
-with st.sidebar.expander(label="Show Paths:", expanded=False):
-    st.markdown(f"### Model Store Path: \n {model_store}")
-    st.markdown(f"### Config Path: \n {config_path}")
-    st.markdown(f"### Log Location: \n {log_location}")
-    st.markdown(f"### Metrics Location: \n {metrics_location}")
-st.sidebar.write(ts_version)
-start = st.sidebar.button("Start Torchserve")
-if start:
-    last_res()[0] = ts.start_torchserve()
-    rerun()
-
-stop = st.sidebar.button("Stop Torchserve")
-if stop:
-    last_res()[0] = ts.stop_torchserve()
-    rerun()
-
-torchserve_status = api.get_loaded_models()
-if torchserve_status:
-    loaded_models_names = [m["modelName"] for m in torchserve_status["models"]]
-else:
-    st.header("Torchserve is down...")
-st.sidebar.subheader("Loaded models")
-st.sidebar.write(torchserve_status)
-
-stored_models = get_model_store()
-st.sidebar.subheader("Available models")
-st.sidebar.write(stored_models)
-####################
-
-st.markdown(f"**Last Message**: {last_res()[0]}")
-
-with st.expander(label="Show torchserve config", expanded=False):
-    st.write(config)
-    st.markdown("[configuration docs](https://pytorch.org/serve/configuration.html)")
-
-if torchserve_status:
-
-    with st.expander(label="Register a model", expanded=False):
-
-        st.markdown(
-            "# Register a model [(docs)](https://pytorch.org/serve/management_api.html#register-a-model)"
-        )
-        placeholder = st.empty()
-        mar_path = placeholder.selectbox(
-            "Choose mar file *", [default_key] + stored_models, index=0
-        )
-        p = st.checkbox("manually enter location")
-        if p:
-            mar_path = placeholder.text_input("Input mar file path*")
-        
-        model_name = st.text_input(label="Model name (overrides predefined)")
-        col1, col2 = st.columns(2)
-        batch_size = col1.number_input(label="batch_size", value=0, min_value=0, step=1)
-        max_batch_delay = col2.number_input(
-            label="max_batch_delay", value=0, min_value=0, step=100
-        )
-        initial_workers = col1.number_input(
-            label="initial_workers", value=1, min_value=0, step=1
-        )
-        response_timeout = col2.number_input(
-            label="response_timeout", value=0, min_value=0, step=100
-        )
-        handler = col1.text_input(label="handler")
-        runtime = col2.text_input(label="runtime")
-        is_encrypted = st.checkbox("SSE-KMS Encrypted", help="Refer to https://github.com/pytorch/serve/blob/v0.5.0/docs/management_api.md#encrypted-model-serving")
-        proceed = st.button("Register")
-        if proceed:
-            if mar_path != default_key:
-                st.write(f"Registering Model...{mar_path}")
-                res = api.register_model(
-                    mar_path,
-                    model_name,
-                    handler=handler,
-                    runtime=runtime,
-                    batch_size=batch_size,
-                    max_batch_delay=max_batch_delay,
-                    initial_workers=initial_workers,
-                    response_timeout=response_timeout,
-                    is_encrypted=is_encrypted,
-                )
-                last_res()[0] = res
-                rerun()
-            else:
-                st.warning(":octagonal_sign: Fill the required fileds!")
-
-    with st.expander(label="Remove a model", expanded=False):
-
-        st.header("Remove a model")
-        model_name = st.selectbox(
-            "Choose model to remove", [default_key] + loaded_models_names, index=0
-        )
-        if model_name != default_key:
-            default_version = api.get_model(model_name)[0]["modelVersion"]
-            st.write(f"default version {default_version}")
-            versions = api.get_model(model_name, list_all=True)
-            versions = [m["modelVersion"] for m in versions]
-            version = st.selectbox(
-                "Choose version to remove", [default_key] + versions, index=0
+            st.markdown(
+                "# Register a model [(docs)](https://pytorch.org/serve/management_api.html#register-a-model)"
             )
-            proceed = st.button("Remove")
+            placeholder = st.empty()
+            mar_path = placeholder.selectbox(
+                "Choose mar file *", [default_key] + stored_models, index=0
+            )
+            p = st.checkbox("manually enter location")
+            if p:
+                mar_path = placeholder.text_input("Input mar file path*")
+            
+            model_name = st.text_input(label="Model name (overrides predefined)")
+            col1, col2 = st.columns(2)
+            batch_size = col1.number_input(label="batch_size", value=0, min_value=0, step=1)
+            max_batch_delay = col2.number_input(
+                label="max_batch_delay", value=0, min_value=0, step=100
+            )
+            initial_workers = col1.number_input(
+                label="initial_workers", value=1, min_value=0, step=1
+            )
+            response_timeout = col2.number_input(
+                label="response_timeout", value=0, min_value=0, step=100
+            )
+            handler = col1.text_input(label="handler")
+            runtime = col2.text_input(label="runtime")
+            is_encrypted = st.checkbox("SSE-KMS Encrypted", help="Refer to https://github.com/pytorch/serve/blob/v0.5.0/docs/management_api.md#encrypted-model-serving")
+            proceed = st.button("Register")
             if proceed:
-                if model_name != default_key and version != default_key:
-                    res = api.delete_model(model_name, version)
+                if mar_path != default_key:
+                    st.write(f"Registering Model...{mar_path}")
+                    res = api.register_model(
+                        mar_path,
+                        model_name,
+                        handler=handler,
+                        runtime=runtime,
+                        batch_size=batch_size,
+                        max_batch_delay=max_batch_delay,
+                        initial_workers=initial_workers,
+                        response_timeout=response_timeout,
+                        is_encrypted=is_encrypted,
+                    )
                     last_res()[0] = res
                     rerun()
                 else:
-                    st.warning(":octagonal_sign: Pick a model & version!")
+                    st.warning(":octagonal_sign: Fill the required fileds!")
 
-    with st.expander(label="Get model details", expanded=False):
+        with st.expander(label="Remove a model", expanded=False):
 
-        st.header("Get model details")
-        model_name = st.selectbox(
-            "Choose model", [default_key] + loaded_models_names, index=0
-        )
-        if model_name != default_key:
-            default_version = api.get_model(model_name)[0]["modelVersion"]
-            st.write(f"default version {default_version}")
-            versions = api.get_model(model_name, list_all=False)
-            versions = [m["modelVersion"] for m in versions]
-            version = st.selectbox(
-                "Choose version", [default_key, "All"] + versions, index=0
+            st.header("Remove a model")
+            model_name = st.selectbox(
+                "Choose model to remove", [default_key] + loaded_models_names, index=0
             )
             if model_name != default_key:
-                if version == "All":
-                    res = api.get_model(model_name, list_all=True)
-                    st.write(res)
-                elif version != default_key:
-                    res = api.get_model(model_name, version)
-                    st.write(res)
-
-    with st.expander(label="Scale workers", expanded=False):
-        st.markdown(
-            "# Scale workers [(docs)](https://pytorch.org/serve/management_api.html#scale-workers)"
-        )
-        model_name = st.selectbox(
-            "Pick model", [default_key] + loaded_models_names, index=0
-        )
-        if model_name != default_key:
-            default_version = api.get_model(model_name)[0]["modelVersion"]
-            st.write(f"default version {default_version}")
-            versions = api.get_model(model_name, list_all=False)
-            versions = [m["modelVersion"] for m in versions]
-            version = st.selectbox("Choose version", ["All"] + versions, index=0)
-
-            col1, col2, col3 = st.columns(3)
-            min_worker = col1.number_input(
-                label="min_worker(optional)", value=-1, min_value=-1, step=1
-            )
-            max_worker = col2.number_input(
-                label="max_worker(optional)", value=-1, min_value=-1, step=1
-            )
-            #             number_gpu = col3.number_input(label="number_gpu(optional)", value=-1, min_value=-1, step=1)
-            proceed = st.button("Apply")
-            if proceed and model_name != default_key:
-                # number_input can't be set to None
-                if version == "All":
-                    version = None
-                if min_worker == -1:
-                    min_worker = None
-                if max_worker == -1:
-                    max_worker = None
-                #                 if number_gpu == -1:
-                #                     number_gpu=None
-
-                res = api.change_model_workers(model_name,
-                                               version=version,
-                                               min_worker=min_worker,
-                                               max_worker=max_worker,
-                                               #                     number_gpu=number_gpu,
-                                               )
-                last_res()[0] = res
-                rerun()
-    if support_workflow:
-        with st.expander(label="Register Workflow", expanded=False):
-            st.markdown(
-                "# Register a workflow [(docs)](https://pytorch.org/serve/workflow_management_api.html#register-a-workflow)"
-            )
-            url = st.text_input("Input war file path or URI *")
-            workflow_name = st.text_input(label="Workflow name (overrides predefined)")
-            if url:
-                res = api.register_workflow(url, workflow_name)
-                st.write(res)
-
-        with st.expander(label="Show Workflow Details", expanded=False):
-            st.markdown(
-                "# Describe a workflow [(docs)](https://pytorch.org/serve/workflow_management_api.html#describe-workflow)"
-            )
-            loaded_workflows = api.list_workflows()  # only upto 100 TODO
-            if loaded_workflows and ("workflows" in loaded_workflows):
-                loaded_workflow_names = [w["workflowName"] for w in loaded_workflows["workflows"]]
-                workflow_name = st.selectbox(
-                    "Pick workflow", [default_key] + loaded_workflow_names, index=0
+                default_version = api.get_model(model_name)[0]["modelVersion"]
+                st.write(f"default version {default_version}")
+                versions = api.get_model(model_name, list_all=True)
+                versions = [m["modelVersion"] for m in versions]
+                version = st.selectbox(
+                    "Choose version to remove", [default_key] + versions, index=0
                 )
-                if workflow_name != default_key:
-                    res = api.get_workflow(workflow_name)
-                    st.write(res)
+                proceed = st.button("Remove")
+                if proceed:
+                    if model_name != default_key and version != default_key:
+                        res = api.delete_model(model_name, version)
+                        last_res()[0] = res
+                        rerun()
+                    else:
+                        st.warning(":octagonal_sign: Pick a model & version!")
 
-        with st.expander(label="Unregister Workflow", expanded=False):
-            st.markdown(
-                "# Unregister a Workflow [(docs)](https://pytorch.org/serve/workflow_management_api.html#unregister-a-workflow)"
+        with st.expander(label="Get model details", expanded=False):
+
+            st.header("Get model details")
+            model_name = st.selectbox(
+                "Choose model", [default_key] + loaded_models_names, index=0
             )
-            loaded_workflows = api.list_workflows()  # only upto 100
-            if loaded_workflows and ("workflows" in loaded_workflows):
-                loaded_workflow_names = [w["workflowName"] for w in loaded_workflows["workflows"]]
-                workflow_name = st.selectbox(
-                    "Unregister workflow", [default_key] + loaded_workflow_names, index=0
+            if model_name != default_key:
+                default_version = api.get_model(model_name)[0]["modelVersion"]
+                st.write(f"default version {default_version}")
+                versions = api.get_model(model_name, list_all=False)
+                versions = [m["modelVersion"] for m in versions]
+                version = st.selectbox(
+                    "Choose version", [default_key, "All"] + versions, index=0
                 )
-                if workflow_name != default_key:
-                    res = api.unregister_workflow(workflow_name)
+                custom_metadata = st.checkbox("Return custom metadata (may freeze/error if not exists!)")
+                if model_name != default_key:
+                    if version == "All":
+                        res = api.get_model(model_name, list_all=True, custom_metadata=custom_metadata)
+                        st.write(res)
+                    elif version != default_key:
+                        res = api.get_model(model_name, version, custom_metadata=custom_metadata)
+                        st.write(res)
+
+        with st.expander(label="Scale workers", expanded=False):
+            st.markdown(
+                "# Scale workers [(docs)](https://pytorch.org/serve/management_api.html#scale-workers)"
+            )
+            model_name = st.selectbox(
+                "Pick model", [default_key] + loaded_models_names, index=0
+            )
+            if model_name != default_key:
+                default_version = api.get_model(model_name)[0]["modelVersion"]
+                st.write(f"default version {default_version}")
+                versions = api.get_model(model_name, list_all=False)
+                versions = [m["modelVersion"] for m in versions]
+                version = st.selectbox("Choose version", ["All"] + versions, index=0)
+
+                col1, col2, col3 = st.columns(3)
+                min_worker = col1.number_input(
+                    label="min_worker(optional)", value=-1, min_value=-1, step=1
+                )
+                max_worker = col2.number_input(
+                    label="max_worker(optional)", value=-1, min_value=-1, step=1
+                )
+                #             number_gpu = col3.number_input(label="number_gpu(optional)", value=-1, min_value=-1, step=1)
+                proceed = st.button("Apply")
+                if proceed and model_name != default_key:
+                    # number_input can't be set to None
+                    if version == "All":
+                        version = None
+                    if min_worker == -1:
+                        min_worker = None
+                    if max_worker == -1:
+                        max_worker = None
+                    #                 if number_gpu == -1:
+                    #                     number_gpu=None
+
+                    res = api.change_model_workers(model_name,
+                                                version=version,
+                                                min_worker=min_worker,
+                                                max_worker=max_worker,
+                                                #                     number_gpu=number_gpu,
+                                                )
+                    last_res()[0] = res
+                    rerun()
+        if support_workflow:
+            with st.expander(label="Register Workflow", expanded=False):
+                st.markdown(
+                    "# Register a workflow [(docs)](https://pytorch.org/serve/workflow_management_api.html#register-a-workflow)"
+                )
+                url = st.text_input("Input war file path or URI *")
+                workflow_name = st.text_input(label="Workflow name (overrides predefined)")
+                if url:
+                    res = api.register_workflow(url, workflow_name)
                     st.write(res)
 
-        with st.expander(label="List Workflows", expanded=False):
-            st.markdown(
-                "# List Workflows"
-            )
-            workflows = []
-            loaded_workflows = api.list_workflows()
-            if loaded_workflows:
-                if "workflows" in loaded_workflows:
-                    workflows.extend(loaded_workflows["workflows"])
-            st.write(workflows)
+            with st.expander(label="Show Workflow Details", expanded=False):
+                st.markdown(
+                    "# Describe a workflow [(docs)](https://pytorch.org/serve/workflow_management_api.html#describe-workflow)"
+                )
+                loaded_workflows = api.list_workflows()  # only upto 100 TODO
+                if loaded_workflows and ("workflows" in loaded_workflows):
+                    loaded_workflow_names = [w["workflowName"] for w in loaded_workflows["workflows"]]
+                    workflow_name = st.selectbox(
+                        "Pick workflow", [default_key] + loaded_workflow_names, index=0
+                    )
+                    if workflow_name != default_key:
+                        res = api.get_workflow(workflow_name)
+                        st.write(res)
+
+            with st.expander(label="Unregister Workflow", expanded=False):
+                st.markdown(
+                    "# Unregister a Workflow [(docs)](https://pytorch.org/serve/workflow_management_api.html#unregister-a-workflow)"
+                )
+                loaded_workflows = api.list_workflows()  # only upto 100
+                if loaded_workflows and ("workflows" in loaded_workflows):
+                    loaded_workflow_names = [w["workflowName"] for w in loaded_workflows["workflows"]]
+                    workflow_name = st.selectbox(
+                        "Unregister workflow", [default_key] + loaded_workflow_names, index=0
+                    )
+                    if workflow_name != default_key:
+                        res = api.unregister_workflow(workflow_name)
+                        st.write(res)
+
+            with st.expander(label="List Workflows", expanded=False):
+                st.markdown(
+                    "# List Workflows"
+                )
+                workflows = []
+                loaded_workflows = api.list_workflows()
+                if loaded_workflows:
+                    if "workflows" in loaded_workflows:
+                        workflows.extend(loaded_workflows["workflows"])
+                st.write(workflows)
+
+if __name__ == "__main__":
+    # Should probably handle argparse in cli.py with click 
+    # but not sure how that would effect passing params to streamlit
+    parser = argparse.ArgumentParser(description="Torchserve Dashboard")
+
+    parser.add_argument(
+        "--model_store", 
+        default=None, 
+        help="Directory where your models are stored (overrides config)"
+    )
+    parser.add_argument(
+        "--config_path",
+        default="./torchserve.properties",
+        help="Torchserve config path",
+    )
+    parser.add_argument(
+        "--log_location",
+        default="./logs/",
+        help="Passed as environment variable LOG_LOCATION to Torchserve",
+    )
+    parser.add_argument(
+        "--metrics_location",
+        default="./logs/metrics/",
+        help="Passed as environment variable METRICS_LOCATION to Torchserve",
+    )
+    parser.add_argument(
+        "--log_config",
+        default=None,
+        help="Overrides the default log4j.properties",
+    )
+    parser.add_argument(
+        "--init",
+        action='store_true',
+        help="Starts torchserve",
+    )
+    try:
+        args = parser.parse_args()
+    except SystemExit as e:
+        os._exit(e.code)
+
+    dashboard(args)


### PR DESCRIPTION
- Better caching using `@st.experimental_singleton`
  - argument parsing and API class initialization should only happen once (across sessions) on initial load. 
  - Should be way better compared to before which ran those functions after each page refresh 😱 Might be optimized further later...need to refactor cli-param parsing/init logic.

- Added `--init` option to initialize torchserve on start. as per this issue: https://github.com/cceyda/torchserve-dashboard/issues/16 
Use like: `torchserve-dashboard --init`
Although you still have to load the dashboard screen once for it to actually start! 

- Update to match changes in torchserve v0.6
  - there seems to be only one update to ManagementAPI in v0.6 https://github.com/pytorch/serve/pull/1421 which adds `?customized=true` option to return custom_metadata in model details. Although the feature seems to be buggy for old .mar files not implementing it. (tested on: https://github.com/pytorch/serve/blob/master/frontend/archive/src/test/resources/models/noop-customized.mar)
  
  Anyway I added a checkbox (defaulted to False) to return custom_metadata if needed.